### PR TITLE
When polling check if data is defined

### DIFF
--- a/priv/bullet.js
+++ b/priv/bullet.js
@@ -59,7 +59,7 @@
 			contentType: 'application/x-www-form-urlencoded; charset=utf-8',
 			headers: {'X-Socket-Transport': 'xhrPolling'},
 			success: function(data){
-				if (data.length !== 0){
+				if (data && data.length !== 0){
 					self.onmessage({'data': data});
 				}
 			}
@@ -181,7 +181,7 @@
 							fake.onopen(fake);
 						}
 						// Connection might have closed without a response body
-						if (data.length !== 0){
+						if (data && data.length !== 0){
 							fake.onmessage({'data': data});
 						}
 						if (fake.readyState == OPEN){


### PR DESCRIPTION
Prevent a javascript error that could stop polling. This happens
when a request returns a 204 No Content. jQuery success callback
has no data in this case causing an error.
