### PR TITLE
Re-added registered key to bullet.app.src

### DIFF
--- a/src/bullet.app.src
+++ b/src/bullet.app.src
@@ -13,14 +13,11 @@
 %% OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 {application, bullet, [
-	{description,
-		"Simple, reliable, efficient streaming for Cowboy."},
-	{vsn, "0.4.1"},
-	{modules, []},
+  {description, "Simple, reliable, efficient streaming for Cowboy."},
+  {vsn, "0.4.1"},
+  {modules, []},
   {registered, []},
-	{applications, [
-		kernel,
-		stdlib,
-		cowboy
-	]}
+  {applications, [
+    kernel, stdlib, cowboy
+  ]}
 ]}.


### PR DESCRIPTION
In order to build an app using bullet (in elixir) with relx i was
unable to include bullet since i was getting the following message:
“bullet: Missing parameter in .app file: registered”
The (re)inclusion allowed to build the app with relx
