### PR TITLE
return true when transport.send returns undefined

### DIFF
--- a/priv/bullet.js
+++ b/priv/bullet.js
@@ -322,12 +322,7 @@
 		this.send = function(data){
 			if (transport){
 				var ret = transport.send(data);
-				if (ret === undefined){
-					return true;
-				}
-				else {
-					return ret;
-				}
+				return (ret === undefined) || ret;
 			} else{
 				return false;
 			}


### PR DESCRIPTION
send() of websocket transport doesn't return value so we must return true
