### PR TITLE
Add send_volatile for WebSocket connections

### DIFF
--- a/priv/bullet.js
+++ b/priv/bullet.js
@@ -327,6 +327,18 @@
 				return false;
 			}
 		};
+		this.send_volatile = function(data){
+			if (transport){
+				if (transport.bufferedAmount === undefined || transport.bufferedAmount === 0) {
+					var ret = transport.send(data);
+					return (ret === undefined) || ret;
+				} else{
+					return true;
+				}
+			} else{
+				return false;
+			}
+		};
 		this.close = function(){
 			readyState = CLOSING;
 			if (transport){


### PR DESCRIPTION
I have a project which uses realtime data to some extent, such as mouse
positions. For that type of data it’s important to me that the peer has
the most up-to-date data possible, and it’s unimportant, and unwanted
that the data gets queued and delivered in a guaranteed manner.

Therefore I added send_volatile(), which only works for WebSockets. It
checks if the WebSocket buffer is empty before sending. For other
transports it just sends as normal.
