### PR TITLE
match error timeout on reply_get_mode, see below:

### DIFF
--- a/src/bullet_handler.erl
+++ b/src/bullet_handler.erl
@@ -210,7 +210,8 @@ reply_get_mode(eventsource, Data, Req) ->
     case cowboy_req:chunk([Event, <<"\n">>], Req) of
         ok -> {loop, Req};
         close -> {ok, Req};
-        {error, closed} -> {ok, Req}
+        {error, closed} -> {ok, Req};
+        {error, timeout} -> {ok, Req}
     end.
 
 %% Internal.


### PR DESCRIPTION
I've seen this in my logs:

```
{[{reason,{case_clause,{error,timeout}}},
    {mfa,{bullet_handler,info,3}},
    {stacktrace,[
    {bullet_handler,reply_get_mode,3,[{file,"bullet/src/bullet_handler.erl"},{line,210}]},
    {bullet_handler,info,3,[{file,"bullet/src/bullet_handler.erl"},{line,116}]},
    {cowboy_handler,handler_call,5,[{file,"cowboy/src/cowboy_handler.erl"},{line,225}]}
```

this new clause handles that case
